### PR TITLE
Use codecov token in the build pipeline + Update readme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,3 +136,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ${{ github.workspace }}/build/reports/kover/report.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,10 +14,20 @@ links. This provider requires the following parameters in the links query parame
 2) `connectionKey`: A URL encoded join link provided by the backend.
 for example, by using `remote-dev-server.sh status`. It will be the one that looks like
 `tcp://127.0.0.1:5990#jt=...`
-3) `pomeriumInstance`: (Optional) a hostname of the pomerium instance to use. By default
+3) `pomeriumInstance`: (Optional) a hostname of the pomerium instance to use. By default,
 the `pomeriumRoute` will be used to connect, but if DNS does not point to pomerium, this can be used
 
 In addition, this plugin implements `GatewayConnector` to allow connecting using the 
 instance via the `jetbrains-gateway://` link without going through the browser (useful for testing)
+
+## Code Coverage
+
+This project uses [Codecov](https://about.codecov.io/) for test coverage metrics, integrated via GitHub Actions. 
+Coverage reports are generated on every build and uploaded to Codecov for visualization and tracking.
+
+For protected branches (e.g., main), a Codecov upload token is required and already configured as a 
+repository secret (`CODECOV_TOKEN`). If you fork this repository or set up a similar workflow, add your 
+own token as a secret and ensure coverage reports are generated at `build/reports/kover/report.xml`. 
+For more details, see the [Codecov docs](https://docs.codecov.com/docs/codecov-tokens).
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Secure Gateway Tunneler
 
-[![codecov](https://codecov.io/github/AdwaitChavan/secure-pomerium-tunneler/graph/badge.svg?token=OBCNTQFDOH)](https://codecov.io/github/AdwaitChavan/secure-pomerium-tunneler)
+[![codecov](https://codecov.io/github/salesforce/secure-pomerium-tunneler/graph/badge.svg?token=R0HHUDVA30)](https://codecov.io/github/salesforce/secure-pomerium-tunneler)
 
 <!-- Plugin description -->
 A Jetbrains Gateway plugin which handles authentication and tunneling through to a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Secure Gateway Tunneler
 
+[![codecov](https://codecov.io/github/AdwaitChavan/secure-pomerium-tunneler/graph/badge.svg?token=OBCNTQFDOH)](https://codecov.io/github/AdwaitChavan/secure-pomerium-tunneler)
+
 <!-- Plugin description -->
 A Jetbrains Gateway plugin which handles authentication and tunneling through to a
 [Pomerium](https://pomerium.io) route for connecting to a IntelliJ backend.


### PR DESCRIPTION
- Currently, main builds are failing due to lack of CodeCov token: `Report creating failed: {"message":"Token required because branch is protected"}` after updating CodeCov library version to v4.
  - https://github.com/salesforce/secure-pomerium-tunneler/actions/runs/18106735199/job/51523238213
  - [raw logs](https://productionresultssa10.blob.core.windows.net/actions-results/57fd42cb-7fcc-49b4-8dc1-4e37912c5bd9/workflow-job-run-bb0f0be6-c9f0-59a9-b29b-73376a82537e/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-10-10T21%3A35%3A06Z&sig=uO%2FIjNX4YysGeG0N6SXJGW4N0dVsKIXOP0ehu%2F7pJwU%3D&ske=2025-10-11T06%3A43%3A48Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-10-10T18%3A43%3A48Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-10-10T21%3A25%3A01Z&sv=2025-11-05)
- The token has been added as a repository secret for this repo
- Ref: https://docs.codecov.com/docs/codecov-tokens