### PR TITLE
add a step to generate Kover Report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,10 @@ jobs:
       - name: Run Tests
         run: ./gradlew check
 
+      # Generate Kover XML coverage report
+      - name: Generate Kover XML coverage report
+        run: ./gradlew koverXmlReport
+
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,13 +119,9 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
 
-      # Run tests
-      - name: Run Tests
+      # Run tests and coverage
+      - name: Run Tests and Coverage
         run: ./gradlew check
-
-      # Generate Kover XML coverage report
-      - name: Generate Kover XML coverage report
-        run: ./gradlew koverXmlReport
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,9 +106,13 @@ changelog {
 }
 tasks {
     kover {
-        reports{
+        reports {
             check(true)
         }
+    }
+
+    check {
+        dependsOn("koverXmlReport")
     }
 
     test {


### PR DESCRIPTION
- Currently, the CI/CD pipeline on `main` is failing as there is no explicit step to generate a kover report