### PR TITLE
Update platform version to 2026.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Set up Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: zulu
           java-version: 21
@@ -108,7 +108,7 @@ jobs:
 
       # Set up Java environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v5.0.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: zulu
           java-version: 21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+## [0.0.3]
+### Changed
+- Upgraded IntelliJ Platform to 2026.1 and updated dependencies
+
+### Fixed
+- Added compatibility fixes for Gateway 2026.1
+
 ## [0.0.2]
 ### Fixed
 - Fixed file descriptor leak

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,8 @@ intellijPlatform {
 // Workaround: Gateway 2026.1 product-info.json has productModuleV2 entries without classPath field.
 // This causes intellij-plugin-structure to fail with NullPointerException during IDE validation.
 // Tracked: https://youtrack.jetbrains.com/issue/IJPL-242405
-// ToDo: Remove this workaround once fixed in Gateway 2026.1.1+ or intellij-plugin-verifier
+// Fixed upstream: https://github.com/JetBrains/intellij-plugin-verifier/pull/1470
+// Remove this workaround once IntelliJ Platform Gradle Plugin bundles the fixed version
 configurations.named("intellijPlatformDependency") {
     incoming.afterResolve {
         resolutionResult.allComponents {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,8 @@ kotlin {
 }
 
 intellijPlatform {
-    version = properties("pluginVersion")
     pluginConfiguration {
+        version = properties("pluginVersion")
         description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
                     val start = "<!-- Plugin description -->"
                     val end = "<!-- Plugin description end -->"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,13 @@ repositories {
     }
 }
 
+// Exclude standard kotlinx-coroutines-core from test configurations to avoid
+// conflicting with IntelliJ platform's patched coroutines (1.10.2-intellij-1)
+configurations.matching { it.name.startsWith("test") }.configureEach {
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+}
+
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     intellijPlatform {
@@ -99,6 +106,36 @@ intellijPlatform {
     }
 }
 
+// Workaround: Gateway 2026.1 product-info.json has productModuleV2 entries without classPath field.
+// This causes intellij-plugin-structure to fail with NullPointerException during IDE validation.
+// Tracked: https://youtrack.jetbrains.com/issue/IJPL-242405
+// ToDo: Remove this workaround once fixed in Gateway 2026.1.1+ or intellij-plugin-verifier
+configurations.named("intellijPlatformDependency") {
+    incoming.afterResolve {
+        resolutionResult.allComponents {
+            val platformPath = moduleVersion?.let {
+                configurations.getByName("intellijPlatformDependency").resolve().firstOrNull()
+            }
+            if (platformPath != null) {
+                listOf(
+                    File(platformPath, "product-info.json"),
+                    File(platformPath, "Resources/product-info.json")
+                ).filter { it.exists() }.forEach { productInfoFile ->
+                    val content = productInfoFile.readText()
+                    if (content.contains(Regex("\"kind\"\\s*:\\s*\"productModuleV2\"\\s*\\}"))) {
+                        productInfoFile.writeText(
+                            content.replace(
+                                Regex("(\"kind\"\\s*:\\s*\"productModuleV2\")\\s*\\}"),
+                                "$1, \"classPath\": []}"
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
     groups.empty()
@@ -117,6 +154,8 @@ tasks {
 
     test {
         useJUnitPlatform()
+        // Byte Buddy (used by Mockito) doesn't officially support Java 25 yet
+        jvmArgs("-Dnet.bytebuddy.experimental=true")
     }
 
     signPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.salesforce.intellij.sgt
 pluginName = Secure Gateway Tunneler
 pluginRepositoryUrl = "https://github.com/salesforce/secure-pomerium-tunneler"
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.2
+pluginVersion = 0.0.3
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,11 +7,11 @@ pluginRepositoryUrl = "https://github.com/salesforce/secure-pomerium-tunneler"
 pluginVersion = 0.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 251
-pluginUntilBuild = 251.*
+pluginSinceBuild = 261
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformVersion = 2025.1.6
+platformVersion = 2026.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,18 +4,18 @@ junit = "5.12.2"
 junit-platform-launcher = "1.12.2"
 coroutine = "1.10.2"
 mockito-kotlin = "5.4.0"
-rdFramework = "2025.1.1"
-httpClient = "5.4.4"
+rdFramework = "2026.1.3"
+httpClient = "5.6"
 rawHttp = "2.6.0"
-ktor = "3.0.3"
+ktor = "3.4.2"
 slf4j = "2.0.17"
-mockWebServer = "4.12.0"
+mockWebServer = "5.3.2"
 
 # plugins
-kotlin = "2.1.21"
+kotlin = "2.3.20"
 changelog = "2.2.1"
-gradleIntelliJPlugin = "2.6.0"
-kover = "0.9.1"
+gradleIntelliJPlugin = "2.11.0"
+kover = "0.9.8"
 
 [libraries]
 junitJupiterApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ mockWebServer = "5.3.2"
 # plugins
 kotlin = "2.3.20"
 changelog = "2.2.1"
-gradleIntelliJPlugin = "2.11.0"
+gradleIntelliJPlugin = "2.13.1"
 kover = "0.9.8"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tunneler/gradle/wrapper/gradle-wrapper.properties
+++ b/tunneler/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
   - Update IntelliJ Gateway platform from 2025.1.6 to **2026.1**. Also update any required dependencies as this update is being made. 