### PR TITLE
Remove product-info.json workaround; upgrade IntelliJ Platform Gradle Plugin to 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # Secure Gateway Tunneler Plugin Changelog
 
 ## [Unreleased]
+### Changed
+- Upgraded IntelliJ Platform Gradle Plugin to 2.16.0
+
+### Fixed
+- Removed workaround for product-info.json productModuleV2 null classPath (fixed in intellij-plugin-structure 3.325, bundled in plugin 2.16.0)
 
 ## [0.0.3]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Secure Gateway Tunneler Plugin Changelog
 
 ## [Unreleased]
+
+## [0.0.4]
 ### Changed
 - Upgraded IntelliJ Platform Gradle Plugin to 2.16.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,37 +106,6 @@ intellijPlatform {
     }
 }
 
-// Workaround: Gateway 2026.1 product-info.json has productModuleV2 entries without classPath field.
-// This causes intellij-plugin-structure to fail with NullPointerException during IDE validation.
-// Tracked: https://youtrack.jetbrains.com/issue/IJPL-242405
-// Fixed upstream: https://github.com/JetBrains/intellij-plugin-verifier/pull/1470
-// Remove this workaround once IntelliJ Platform Gradle Plugin bundles the fixed version
-configurations.named("intellijPlatformDependency") {
-    incoming.afterResolve {
-        resolutionResult.allComponents {
-            val platformPath = moduleVersion?.let {
-                configurations.getByName("intellijPlatformDependency").resolve().firstOrNull()
-            }
-            if (platformPath != null) {
-                listOf(
-                    File(platformPath, "product-info.json"),
-                    File(platformPath, "Resources/product-info.json")
-                ).filter { it.exists() }.forEach { productInfoFile ->
-                    val content = productInfoFile.readText()
-                    if (content.contains(Regex("\"kind\"\\s*:\\s*\"productModuleV2\"\\s*\\}"))) {
-                        productInfoFile.writeText(
-                            content.replace(
-                                Regex("(\"kind\"\\s*:\\s*\"productModuleV2\")\\s*\\}"),
-                                "$1, \"classPath\": []}"
-                            )
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
     groups.empty()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.salesforce.intellij.sgt
 pluginName = Secure Gateway Tunneler
 pluginRepositoryUrl = "https://github.com/salesforce/secure-pomerium-tunneler"
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.3
+pluginVersion = 0.0.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ mockWebServer = "5.3.2"
 # plugins
 kotlin = "2.3.20"
 changelog = "2.5.0"
-gradleIntelliJPlugin = "2.14.0"
+gradleIntelliJPlugin = "2.16.0"
 kover = "0.9.8"
 
 [libraries]


### PR DESCRIPTION
## Summary

- Upgraded IntelliJ Platform Gradle Plugin from 2.14.0 → 2.16.0
- Removed the `product-info.json` `productModuleV2` null `classPath` workaround

## Context

The workaround was added in #14 to work around a null `classPath` NPE in `intellij-plugin-structure` when validating Gateway 2026.1. The fix was tracked in [IJPL-242405](https://youtrack.jetbrains.com/issue/IJPL-242405) and merged upstream in [JetBrains/intellij-plugin-verifier#1470](https://github.com/JetBrains/intellij-plugin-verifier/pull/1470).

The fix landed in `intellij-plugin-structure 3.325`. Plugin 2.16.0 bundles `3.326`, so the workaround is no longer needed.

## Test plan

- [x] `./gradlew check --no-daemon` passes with plugin 2.16.0 and without the workaround
- [x] All 26 tasks complete successfully (BUILD SUCCESSFUL)